### PR TITLE
Fix track_exception for non-str exception args

### DIFF
--- a/applicationinsights/TelemetryClient.py
+++ b/applicationinsights/TelemetryClient.py
@@ -98,7 +98,7 @@ class TelemetryClient(object):
         details.id = 1
         details.outer_id = 0
         details.type_name = type.__name__
-        details.message = ''.join(value.args)
+        details.message = str(value)
         details.has_full_stack = True
         counter = 0
         for tb_frame_file, tb_frame_line, tb_frame_function, tb_frame_text in traceback.extract_tb(tb):


### PR DESCRIPTION
exc_value.args may contain members that aren't strings, which will cause ''.join() to raise an error. Calling str on the exception will produce the message as intended by the exception creator, which for most standard exceptions is the same as ''.join(args).

It may be nice to submit each arg as a string too, but that probably needs changes elsewhere which I'm not prepared to make. `[str(a) for a in value.args]` is the best way to get a list of values to submit.